### PR TITLE
Fix to check exactly true for open-statuses

### DIFF
--- a/orgmine.el
+++ b/orgmine.el
@@ -3200,7 +3200,7 @@ Then entry could be an issue, version, tracker or project."
 	 open-statuses closed-statuses)
     (mapc (lambda (status)
 	    (let ((name (orgmine-name status nil nil)))
-	      (if (plist-get status :is_closed)
+	      (if (eq t (plist-get status :is_closed))
 		  (add-to-list 'closed-statuses name)
 		(add-to-list 'open-statuses name))))
 	  (nreverse issue-statuses))


### PR DESCRIPTION
If data comes like the below from Redmine(4.2.2),
```
((:id 1 :name "New" :is_closed :json-false) (:id 2 :name "In progress" :is_closed :json-false) (:id 3 :name "Resolved" :is_closed :json-false) (:id 4 :name "Feedback" :is_closed :json-false) (:id 5 :name "Closed" :is_closed t) (:id 6 :name "Rejected" :is_closed t))
```

The checking status won't work. So orgmine needs to check `:is_closed` is true exactly.

```elisp
(setq status '(:id 1 :name "New" :is_closed :json-false))
(plist-get status :is_closed)
;; :json-false => wrong

(setq status '(:id 6 :name "Rejected" :is_closed t))
(plist-get status :is_closed)
;; t => correct

(setq status '(:id 1 :name "New" :is_closed :json-false))
(eq t (plist-get status :is_closed))
;; nil => correct
```