### PR TITLE
org-file-properties was renamed to org-keyword-properties

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,7 +37,7 @@ Note that "om_project" property is a mandatory property to use orgmine.
 #+begin_src emacs-lisp
   (require 'orgmine)
   (add-hook 'org-mode-hook
-            (lambda () (if (assoc "om_project" org-file-properties)
+            (lambda () (if (assoc "om_project" org-keyword-properties)
                            (orgmine-mode))))
 #+end_src
 


### PR DESCRIPTION
Not really sure when or more details, but I found some mention at mailing list: https://list.orgmode.org/HE1PR02MB303336E5646F7E8233DC83FFDA830@HE1PR02MB3033.eurprd02.prod.outlook.com/T/ and couple requests for rename in different projects